### PR TITLE
Details

### DIFF
--- a/Frontend/src/components/Dashboard.js
+++ b/Frontend/src/components/Dashboard.js
@@ -26,9 +26,10 @@ const Dashboard = () => {
         ></Overview>
         </div>
       <div className='row-span-2 xl-row-span-3'>
-        <Details details={mockCompanyDetails}>
-
-        </Details>
+        <Details 
+        details={mockCompanyDetails} 
+        summary={mockCurrentQuote}
+        ></Details>
         </div>
     </div>
   )

--- a/Frontend/src/components/Details.js
+++ b/Frontend/src/components/Details.js
@@ -27,15 +27,23 @@ const Details = ({ details, summary }) => {
          <Cards>
             <ul className='w-full h-full flex flex-col justify-between divide-y-1'>
                {Object.keys(companySummary).map((item) => {
-                   return (
-                   <li 
-                   key={item} 
-                   className="flex-1 flex justify-between items-center"
-                   >
-                      <span>{item}:</span>
-                      <span>{companySummary[item]}</span>
-                   </li>
-                   )
+
+                  let value = companySummary[item];
+
+                  if (!isNaN(parseFloat(value))) {
+                     if (item === "Volume") {
+                           value = parseInt(value, 10).toLocaleString();
+                     } else {
+                           value = parseFloat(value).toFixed(2);
+                     }
+                     value = value.toLocaleString(); 
+                  }
+                  return (
+                     <li key={item} className="flex-1 flex justify-between items-center">
+                        <span>{item}:</span>
+                        <span>{isNaN(parseFloat(value)) ? companySummary[item] : value}</span>
+                     </li>
+                     );
                })}
             </ul>
          </Cards>

--- a/Frontend/src/components/Details.js
+++ b/Frontend/src/components/Details.js
@@ -1,39 +1,39 @@
 import React from 'react';
 import Cards from './Cards';
 
-const Details = ({ details }) => {
-   const CompanyLists = ({ details }) => {
+const Details = ({ details, summary }) => {
+   const CompanyLists = ({ details, summary }) => {
       const companyDetails = {
-         Name: details.Name,
-         Country: details.Country,
-         Currency: details.Currency,
-         Exchange: details.Exchange,
-         Sector: details.Sector,
-         Industry: details.Industry
+         "Name": details.Name,
+         "Country": details.Country,
+         "Currency": details.Currency,
+         "Exchange": details.Exchange,
+         "Sector": details.Sector,
+         "Industry": details.Industry
       };
 
+      const globalQuote = summary && summary["Global Quote"] ? summary["Global Quote"] : {};
+      
       const companySummary = {
-         previousClose: 'Previous Close',
-         open: 'Open',
-         daysRange: "Day's Range",
-         fiftyTwoRange: '52 Week Range',
-         volume: 'Volume',
-         marketCap: 'Market Cap',
-         peRation: 'PE Ratio (TTM)',
-         eps: 'EPS (TTM)'
+         "Previous Close": globalQuote["08. previous close"] || 'N/A',
+         "Open": globalQuote["02. open"] || 'N/A',
+         "High": globalQuote["03. high"] || 'N/A',
+         "Low": globalQuote["04. low"] || 'N/A',
+         "Price": globalQuote["05. price"] || 'N/A',
+         "Volume": globalQuote["06. volume"] || 'N/A'
       };
 
       return (
          <Cards>
             <ul className='w-full h-full flex flex-col justify-between divide-y-1'>
-               {Object.keys(companyDetails).map((item) => {
+               {Object.keys(companySummary).map((item) => {
                    return (
                    <li 
                    key={item} 
                    className="flex-1 flex justify-between items-center"
                    >
                       <span>{item}:</span>
-                      <span>{companyDetails[item]}</span>
+                      <span>{companySummary[item]}</span>
                    </li>
                    )
                })}
@@ -42,7 +42,8 @@ const Details = ({ details }) => {
       );
    };
 
-   return <CompanyLists details={details} />;
+   return <CompanyLists details={details} summary={summary} />;
+
 };
 
 export default Details;


### PR DESCRIPTION
merged Details sections to include information on company summary and company details; I want to apply a toggle button two switch between the two pieces of information. For the time being, it will only display the summary of price information.

** Notes
 - added toLocaleString() to format the volume with commas for better readability
 - added parsefloat() to limit the number of digits after the decimal point for the props that represent monetary values